### PR TITLE
Fix missing setuptools in multiqc Docker image

### DIFF
--- a/docker/Dockerfile.multiqc
+++ b/docker/Dockerfile.multiqc
@@ -19,6 +19,7 @@ RUN \
   conda install --prefix /env/ git
 
 RUN \
+  conda run --prefix /env/ pip install setuptools && \
   conda run --prefix /env/ pip install 'multiqc ==1.15' && \
   conda run --prefix /env/ pip install 'git+https://github.com/umccr/multiqc_template@v0.0.3'
 


### PR DESCRIPTION
## Summary

- `multiqc==1.15` depends on `pkg_resources` which is part of `setuptools`
- `setuptools` used to be bundled with conda-forge Python packages by default, but was removed as a default dependency in late 2024
- When the `0.2.18-multiqc` image was rebuilt, the resolved conda environment no longer included `setuptools`, causing multiqc to fail with `ModuleNotFoundError: No module named 'pkg_resources'`

## Fix

Explicitly install `setuptools` via pip before installing multiqc in `Dockerfile.multiqc`.