### PR TITLE
fix setuptools version to include pkg_resources

### DIFF
--- a/docker/Dockerfile.multiqc
+++ b/docker/Dockerfile.multiqc
@@ -19,9 +19,9 @@ RUN \
   conda install --prefix /env/ git
 
 RUN \
-  conda run --prefix /env/ pip install setuptools && \
   conda run --prefix /env/ pip install 'multiqc ==1.15' && \
-  conda run --prefix /env/ pip install 'git+https://github.com/umccr/multiqc_template@v0.0.3'
+  conda run --prefix /env/ pip install 'git+https://github.com/umccr/multiqc_template@v0.0.3' && \
+  conda run --prefix /env/ pip install 'setuptools<70'
 
 COPY ./ /tmp/bolt/
 RUN \


### PR DESCRIPTION
## Summary
- Pin `setuptools<70` to ensure `pkg_resources` is available as a top-level module
- setuptools 70+ moved `pkg_resources` inside the package, breaking `import pkg_resources` used by multiqc 1.15
- Install must happen after multiqc to prevent being overridden by dependency resolution