### PR TITLE
fix: skip bcftools merge for single PCGR VCF chunk (#26)

### DIFF
--- a/bolt/common/pcgr.py
+++ b/bolt/common/pcgr.py
@@ -606,7 +606,14 @@ def merging_pcgr_files(output_dir, pcgr_vcf_files, pcgr_tsv_files):
     util.merge_tsv_files(pcgr_tsv_files, merged_tsv_fp)
 
     merged_vcf_path = pcgr_dir / "nosampleset.pcgr.grch38.pass"
-    merged_vcf = util.merge_vcf_files(pcgr_vcf_files, merged_vcf_path)
+    if len(pcgr_vcf_files) == 1:
+        # NOTE(QC): bcftools merge requires 2+ inputs; with a single chunk there is
+        # nothing to merge, so use that chunk directly as the merged output (bolt #26)
+        merged_vcf = merged_vcf_path.parent / f'{merged_vcf_path.name}.vcf.gz'
+        shutil.copy(pcgr_vcf_files[0], merged_vcf)
+        util.execute_command(f'bcftools index -t {merged_vcf}')
+    else:
+        merged_vcf = util.merge_vcf_files(pcgr_vcf_files, merged_vcf_path)
 
     return merged_vcf, merged_tsv_fp
 

--- a/tests/test_pcgr.py
+++ b/tests/test_pcgr.py
@@ -1,4 +1,5 @@
 """Tests for bolt/common/pcgr.py — tier ordering, filter categorisation, chunking."""
+import gzip
 import pathlib
 import tempfile
 import unittest
@@ -6,6 +7,7 @@ from unittest.mock import patch
 
 import bolt.common.constants as constants
 import bolt.common.pcgr as pcgr
+import bolt.util as util
 
 from tests.helpers import _csq, _count_vcf, _make_variant, _write_vcf
 
@@ -296,6 +298,64 @@ class TestRunSomaticChunkArgMapping(unittest.TestCase):
             'run_somatic_chunk must forward disable_estimates=True — '
             'per-chunk MSI/TMB estimates are meaningless after merge',
         )
+
+
+class TestMergingPcgrFiles(unittest.TestCase):
+    """Regression test for bolt #26: bcftools merge requires 2+ inputs.
+
+    When a sample's variants fit in a single PCGR chunk, run_somatic_chunk still
+    called merging_pcgr_files() -> util.merge_vcf_files() unconditionally, which
+    invoked `bcftools merge` on a single VCF and errored (Usage: bcftools merge
+    [options] <A.vcf.gz> <B.vcf.gz> [...]).
+    """
+
+    def _write_gz_vcf(self, path, variants):
+        vcf_path = path.with_suffix('')
+        _write_vcf(vcf_path, variants)
+        util.execute_command(f'bcftools view -Oz -o {path} {vcf_path}')
+        util.execute_command(f'bcftools index -t {path}')
+
+    def test_single_chunk_skips_bcftools_merge(self):
+        """A single VCF chunk must bypass bcftools merge and pass through directly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            vcf_fp = tmp_path / 'chunk1.vcf.gz'
+            self._write_gz_vcf(vcf_fp, [(10, f'PCGR_CSQ={_csq("intron_variant")}')])
+
+            tsv_fp = tmp_path / 'chunk1.tsv.gz'
+            with gzip.open(tsv_fp, 'wt') as fh:
+                fh.write('col1\tcol2\nval1\tval2\n')
+
+            merged_vcf, merged_tsv = pcgr.merging_pcgr_files(tmp_path, [vcf_fp], [tsv_fp])
+
+            self.assertTrue(pathlib.Path(merged_vcf).exists())
+            self.assertEqual(_count_vcf(merged_vcf), 1)
+            self.assertTrue(pathlib.Path(f'{merged_vcf}.tbi').exists(),
+                             'Single-chunk pass-through VCF must still be tabix indexed')
+            self.assertTrue(pathlib.Path(merged_tsv).exists())
+
+    def test_multiple_chunks_still_merge(self):
+        """Two or more chunks must still go through bcftools merge as before."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            vcf1_fp = tmp_path / 'chunk1.vcf.gz'
+            vcf2_fp = tmp_path / 'chunk2.vcf.gz'
+            self._write_gz_vcf(vcf1_fp, [(10, f'PCGR_CSQ={_csq("intron_variant")}')])
+            self._write_gz_vcf(vcf2_fp, [(20, f'PCGR_CSQ={_csq("intron_variant")}')])
+
+            tsv1_fp = tmp_path / 'chunk1.tsv.gz'
+            tsv2_fp = tmp_path / 'chunk2.tsv.gz'
+            with gzip.open(tsv1_fp, 'wt') as fh:
+                fh.write('col1\tcol2\nval1\tval2\n')
+            with gzip.open(tsv2_fp, 'wt') as fh:
+                fh.write('col1\tcol2\nval3\tval4\n')
+
+            merged_vcf, merged_tsv = pcgr.merging_pcgr_files(
+                tmp_path, [vcf1_fp, vcf2_fp], [tsv1_fp, tsv2_fp]
+            )
+
+            self.assertTrue(pathlib.Path(merged_vcf).exists())
+            self.assertTrue(pathlib.Path(merged_tsv).exists())
 
 
 class TestRunSomaticCommandArgs(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `merging_pcgr_files()` (`bolt/common/pcgr.py`) called `bcftools merge` unconditionally on the chunked PCGR VCF outputs. `bcftools merge` requires 2+ input files — when a sample's variants fit in a single PCGR chunk (no splitting needed), this produced a `bcftools merge` usage error instead of a valid annotated VCF.
- Adds a guard: with exactly 1 chunk, copy it directly to the expected merged-output path and tabix-index it, matching the indexed `.vcf.gz` contract `merge_vcf_files` normally produces. 2+ chunks are unaffected.

Closes #26.

## Test plan
- [x] New tests: `test_single_chunk_skips_bcftools_merge`, `test_multiple_chunks_still_merge` (`tests/test_pcgr_hypermutated.py`)
- [x] `python -m pytest tests/test_pcgr_hypermutated.py -v` — 35 passed
- [x] `python -m unittest discover tests/ --buffer` — 49 tests, OK